### PR TITLE
gas prognose

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,33 @@
 
 Degree days integration for Home Assistant based on KNMI weather station data (the Netherlands)
 
-Currently still in development, not ready yet for production
+This integration will collect daily average temperature from a KNMI weather station and will calculate the total number of degree days and the weighted total number of degree days this year (similar as is done on the [mindergas website](www.mindergas.nl)).
+
+Weigthed degree days are determined by multiplying the number of degree days in a certain month with a certain factor. The applied multiplication factors are:
+
+- April till September: 0,8
+- March and October: 1,0
+- November till Februari: 1,1
+
+You can add a gas sensor to calculate the gas consumption per weighted degree day from the start of the year, which can be used to compare your gas usage with other users or previous years, taking into account the temperature in a certain year. For more information on degree days and its use, have a look at the website [Degree Days.net](https://www.degreedays.net/) (English) or [Mindergas](https://mindergas.nl/degree_days/explanation) (Dutch)
+
+The Degree Days integration has the following options
+
+
+- **Weather station (KNMI)**
+KNMI Weather station to get the daily mean outdoor temperatures. Currently only Dutch weather stations are supported. 
+
+- **Mean indoor temperature**
+Estimated daily mean indoor temperature during day and night, averaged over one year. Default setting: 18°C.
+
+- **Heating temperature limit**
+In the spring and autumn, the heating will not always be turned on directly, even if the daily mean outdoor temperature is below the daily mean indoor temperature. Buildings will collect heat during hot periods in e.g. concrete walls, which is released gradually, preventing the heating to turn on. By setting a different heating temperature limit (e.g. 15,5°C), degree days will only be counted if the daily mean outdoor temperature is lower than this heating temperature limit. A lower value for the heating temperature will increase the gas consumption per degree day in the spring and autumn. 
+
+- **Startday for sum of total degree days**
+Day of the month from which the yearly totals are computed. When used in combination with a gas sensor, this has to be the same day as the yearly total gas consumption is determined. 
+
+- **Startmonth for sum of total degree days**
+Month from which the yearly totals are computed. When used in combination with a gas sensor, this has to be the same day as the yearly total gas consumption is determined. 
+
+- **Gas sensor entity**
+Gas sensor entity with the total consumption this year.

--- a/custom_components/degree_days/config_flow.py
+++ b/custom_components/degree_days/config_flow.py
@@ -5,26 +5,22 @@ import logging
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 
 from .const import (
+    CONF_GAS_SENSOR,
     CONF_HEATING_LIMIT,
     CONF_INDOOR_TEMP,
-    CONF_WEATHER_STATION,
     CONF_STARTDAY,
     CONF_STARTMONTH,
-    CONF_GAS_CONSUMPTION,
-    CONF_GAS_SENSOR,
+    CONF_WEATHER_STATION,
+    DEFAULT_GAS_SENSOR,
     DEFAULT_HEATING_LIMIT,
     DEFAULT_INDOOR_TEMP,
-    DEFAULT_NAME,
-    DEFAULT_WEATHER_STATION,
     DEFAULT_STARTDAY,
     DEFAULT_STARTMONTH,
-    DEFAULT_GAS_CONSUMPTION,
-    DEFAULT_GAS_SENSOR,
+    DEFAULT_WEATHER_STATION,
     DOMAIN,
     MONTHS,
     STATION_MAPPING
@@ -58,27 +54,25 @@ class DegreeDaysConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             valid_date = await self._date_validation(
                 user_input[CONF_STARTDAY], user_input[CONF_STARTMONTH]
             )
-            valid_station = await self._weather_station_in_configuration_exists(
+            invalid_station = await self._weather_station_in_configuration_exists(
                 self.hass, user_input[CONF_WEATHER_STATION]
             )
             if not valid_date:
                  self._errors[CONF_STARTDAY] = "invalid_startday"
-            elif not valid_station:
+            elif invalid_station:
                 self._errors[CONF_WEATHER_STATION] = "already_configured"
             else:
                 return self.async_create_entry(
-                    title=user_input[CONF_NAME], data=user_input
+                    title="Degree Days", data=user_input
                 )
 
         user_input = {}
         # Provide defaults for form
-        user_input[CONF_NAME] = DEFAULT_NAME
-        user_input[CONF_HEATING_LIMIT] = DEFAULT_HEATING_LIMIT
-        user_input[CONF_INDOOR_TEMP] = DEFAULT_INDOOR_TEMP
         user_input[CONF_WEATHER_STATION] = DEFAULT_WEATHER_STATION
+        user_input[CONF_INDOOR_TEMP] = DEFAULT_INDOOR_TEMP
+        user_input[CONF_HEATING_LIMIT] = DEFAULT_HEATING_LIMIT
         user_input[CONF_STARTDAY] = DEFAULT_STARTDAY
         user_input[CONF_STARTMONTH] = DEFAULT_STARTMONTH
-        user_input[CONF_GAS_CONSUMPTION] = DEFAULT_GAS_CONSUMPTION
         user_input[CONF_GAS_SENSOR] = DEFAULT_GAS_SENSOR
 
         return await self._show_config_form(user_input)
@@ -94,27 +88,21 @@ class DegreeDaysConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=vol.Schema(
                 {
-                    vol.Required(
-                        CONF_NAME, default=user_input.get(CONF_NAME, DEFAULT_NAME)
-                    ): str,
                     vol.Optional(
-                        CONF_HEATING_LIMIT, default=user_input.get(CONF_HEATING_LIMIT, DEFAULT_HEATING_LIMIT)
-                    ): cv.positive_int,
-                    vol.Optional(
-                        CONF_INDOOR_TEMP, default=user_input.get(CONF_INDOOR_TEMP, DEFAULT_INDOOR_TEMP)
-                    ): cv.positive_int,
-                    vol.Required(
                         CONF_WEATHER_STATION, default=user_input.get(CONF_WEATHER_STATION, DEFAULT_WEATHER_STATION)
                     ): vol.In(list(STATION_MAPPING)),
-                    vol.Required(
+                    vol.Optional(
+                        CONF_INDOOR_TEMP, default=user_input.get(CONF_INDOOR_TEMP, DEFAULT_INDOOR_TEMP)
+                    ): cv.positive_float,
+                    vol.Optional(
+                        CONF_HEATING_LIMIT, default=user_input.get(CONF_HEATING_LIMIT, DEFAULT_HEATING_LIMIT)
+                    ): cv.positive_float,
+                    vol.Optional(
                         CONF_STARTDAY, default=user_input.get(CONF_STARTDAY, DEFAULT_STARTDAY)
                     ): cv.positive_int,
-                    vol.Required(
+                    vol.Optional(
                         CONF_STARTMONTH, default=user_input.get(CONF_STARTMONTH, DEFAULT_STARTMONTH)
                     ):  vol.In(MONTHS),
-                    vol.Optional(
-                        CONF_GAS_CONSUMPTION, default=user_input.get(CONF_GAS_CONSUMPTION, DEFAULT_GAS_CONSUMPTION)
-                    ): cv.positive_int,
                     vol.Optional(
                         CONF_GAS_SENSOR, default=user_input.get(CONF_GAS_SENSOR, DEFAULT_GAS_SENSOR)
                     ): str,
@@ -122,6 +110,7 @@ class DegreeDaysConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             ),
             errors=self._errors,
         )
+
     async def _date_validation(self, startday, startmonth) -> bool:
         """Return True if day and month is a correct date."""
         isValidDate = True
@@ -133,7 +122,7 @@ class DegreeDaysConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         except ValueError:
             return False
 
-    async def weather_station_in_configuration_exists(hass, weather_station_entry) -> bool:
+    async def _weather_station_in_configuration_exists(self, hass, weather_station_entry) -> bool:
         """Return True if weather station exists in configuration."""
         if weather_station_entry in degree_days_entries(hass):
             return True
@@ -168,28 +157,23 @@ class DegreeDaysOptionsFlowHandler(config_entries.OptionsFlow):
             step_id="user",
             data_schema=vol.Schema(
                 {
-                    vol.Required(
-                        CONF_NAME, default=self.options.get(CONF_NAME, DEFAULT_NAME)
-                    ): str,
                     vol.Optional(
-                        CONF_HEATING_LIMIT, default=self.options.get(CONF_HEATING_LIMIT, DEFAULT_HEATING_LIMIT)
-                    ): cv.positive_int,
-                    vol.Optional(
-                        CONF_INDOOR_TEMP, default=self.options.get(CONF_INDOOR_TEMP, DEFAULT_INDOOR_TEMP)
-                    ): cv.positive_int,
-                    vol.Required(
                         CONF_WEATHER_STATION, default=self.options.get(CONF_WEATHER_STATION, DEFAULT_WEATHER_STATION)
                     ): vol.In(list(STATION_MAPPING)),
-                    vol.Required(
+                    vol.Optional(
+                        CONF_INDOOR_TEMP, default=self.options.get(CONF_INDOOR_TEMP, DEFAULT_INDOOR_TEMP)
+                    ): cv.positive_float,
+                    vol.Optional(
+                        CONF_HEATING_LIMIT, default=self.options.get(CONF_HEATING_LIMIT, DEFAULT_HEATING_LIMIT)
+                    ): cv.positive_float,
+                    vol.Optional(
                         CONF_STARTDAY, default=self.options.get(CONF_STARTDAY, DEFAULT_STARTDAY)
                     ): cv.positive_int,
-                    vol.Required(
+                    vol.Optional(
                         CONF_STARTMONTH, default=self.options.get(CONF_STARTMONTH, DEFAULT_STARTMONTH)
                     ):  vol.In(MONTHS),
                     vol.Optional(
-                        CONF_GAS_CONSUMPTION, default=self.options.get(CONF_GAS_CONSUMPTION, DEFAULT_GAS_CONSUMPTION)
-                    ): cv.positive_int,
-                    vol.Optional(CONF_GAS_SENSOR, default=self.options.get(CONF_GAS_SENSOR, DEFAULT_GAS_SENSOR)
+                        CONF_GAS_SENSOR, default=self.options.get(CONF_GAS_SENSOR, DEFAULT_GAS_SENSOR)
                     ): str,
                 }
             ),
@@ -199,7 +183,7 @@ class DegreeDaysOptionsFlowHandler(config_entries.OptionsFlow):
     async def _update_options(self):
         """Update config entry options."""
         return self.async_create_entry(
-            title=self.config_entry.data.get(CONF_NAME), data=self.options
+            title="Degree Days", data=self.options
         )
 
     async def _date_validation(self, startday, startmonth) -> bool:

--- a/custom_components/degree_days/const.py
+++ b/custom_components/degree_days/const.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from homeassistant.components.sensor import (
+    DEVICE_CLASS_GAS,
     STATE_CLASS_MEASUREMENT,
-    STATE_CLASS_TOTAL_INCREASING,
+    STATE_CLASS_TOTAL,
     SensorEntityDescription,
 )
 from homeassistant.const import (
@@ -22,16 +23,13 @@ CONF_INDOOR_TEMP = "mean indoor temperature"
 CONF_WEATHER_STATION = "weather station"
 CONF_STARTDAY = "startday"
 CONF_STARTMONTH = "startmonth"
-CONF_GAS_CONSUMPTION = "gas consumption"
 CONF_GAS_SENSOR = "gas sensor"
 
 DEFAULT_HEATING_LIMIT = 18.0
 DEFAULT_INDOOR_TEMP = 18.0
-DEFAULT_NAME = "degree days"
 DEFAULT_WEATHER_STATION = "De Bilt"
 DEFAULT_STARTDAY = "01"
 DEFAULT_STARTMONTH = "January"
-DEFAULT_GAS_CONSUMPTION = 1500
 DEFAULT_GAS_SENSOR = ""
 
 # KNMI weather stations (NL).
@@ -129,7 +127,7 @@ SENSOR_TYPES: tuple[DegreeDaysSensorEntityDescription, ...] = (
         icon="mdi:thermometer",
         native_unit_of_measurement=TEMP_CELSIUS,
         device_class=None,
-        state_class=STATE_CLASS_TOTAL_INCREASING,
+        state_class=STATE_CLASS_TOTAL,
     ),
     DegreeDaysSensorEntityDescription(
         key="weighted_degree_days_year",
@@ -137,6 +135,22 @@ SENSOR_TYPES: tuple[DegreeDaysSensorEntityDescription, ...] = (
         icon="mdi:thermometer",
         native_unit_of_measurement=TEMP_CELSIUS,
         device_class=None,
-        state_class=STATE_CLASS_TOTAL_INCREASING,
+        state_class=STATE_CLASS_TOTAL,
+    ),
+    DegreeDaysSensorEntityDescription(
+        key="gas_per_weighted_degree_day",
+        name="gas consumption per weighted degree day",
+        icon="mdi:fire",
+        native_unit_of_measurement=VOLUME_CUBIC_METERS,
+        device_class=DEVICE_CLASS_GAS,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    DegreeDaysSensorEntityDescription(
+        key="gas_prognose",
+        name="gas prognose",
+        icon="mdi:fire",
+        native_unit_of_measurement=VOLUME_CUBIC_METERS,
+        device_class=DEVICE_CLASS_GAS,
+        state_class=STATE_CLASS_TOTAL,
     ),
 )

--- a/custom_components/degree_days/manifest.json
+++ b/custom_components/degree_days/manifest.json
@@ -5,7 +5,7 @@
     "documentation": "https://www.home-assistant.io/integrations/degree_days",
     "codeowners": ["@Ernst79", "@nelbs"],
     "requirements": [],
-    "version": "0.4.0",
+    "version": "0.5.0",
     "iot_class": "cloud_polling"
   }
   

--- a/custom_components/degree_days/strings.json
+++ b/custom_components/degree_days/strings.json
@@ -4,13 +4,11 @@
       "user": {
         "title": "Define your Degree Days integration",
         "data": {
-          "name": "The prefix to be used for your Degree Day sensors",
-          "heating limit": "Heating temperature limit",
-          "mean indoor temperature": "Mean indoor temperature",
           "weather station": "Weather station (KNMI)",
+          "mean indoor temperature": "Mean indoor temperature",
+          "heating limit": "Heating temperature limit",
           "startday": "Startday for sum of total degree days",
           "startmonth": "Startmonth for sum of total degree days",
-          "gas consumption": "Gas consumption in m3 (will be changed later to a sensor entity)",
           "gas sensor": "Gas sensor entity"
         }
       }
@@ -29,13 +27,11 @@
       "user": {
         "title": "Degree Days integration options",
         "data": {
-          "name": "The prefix to be used for your Degree Day sensors",
-          "heating limit": "Heating temperature limit",
-          "mean indoor temperature": "Mean indoor temperature",
           "weather station": "Weather station (KNMI)",
+          "mean indoor temperature": "Mean indoor temperature",
+          "heating limit": "Heating temperature limit",
           "startday": "Startday for sum of total degree days",
           "startmonth": "Startmonth for sum of total degree days",
-          "gas consumption": "Gas consumption in m3 (will be changed later to a sensor entity)",
           "gas sensor": "Gas sensor entity"
         }
       }

--- a/custom_components/degree_days/translations/en.json
+++ b/custom_components/degree_days/translations/en.json
@@ -4,13 +4,11 @@
       "user": {
         "title": "Define your Degree Days integration",
         "data": {
-          "name": "The prefix to be used for your Degree Day sensors",
-          "heating limit": "Heating temperature limit",
-          "mean indoor temperature": "Mean indoor temperature",
           "weather station": "Weather station (KNMI)",
+          "mean indoor temperature": "Mean indoor temperature",
+          "heating limit": "Heating temperature limit",
           "startday": "Startday for sum of total degree days",
           "startmonth": "Startmonth for sum of total degree days",
-          "gas consumption": "Gas consumption in m3 (will be changed later to a sensor entity)",
           "gas sensor": "Gas sensor entity"
         }
       }
@@ -29,13 +27,11 @@
       "user": {
         "title": "Degree Days integration options",
         "data": {
-          "name": "The prefix to be used for your Degree Day sensors",
-          "heating limit": "Heating temperature limit",
-          "mean indoor temperature": "Mean indoor temperature",
           "weather station": "Weather station (KNMI)",
+          "mean indoor temperature": "Mean indoor temperature",
+          "heating limit": "Heating temperature limit",
           "startday": "Startday for sum of total degree days",
           "startmonth": "Startmonth for sum of total degree days",
-          "gas consumption": "Gas consumption in m3 (will be changed later to a sensor entity)",
           "gas sensor": "Gas sensor entity"
         }
       }

--- a/custom_components/degree_days/translations/nl.json
+++ b/custom_components/degree_days/translations/nl.json
@@ -4,13 +4,11 @@
       "user": {
         "title": "Definieer de Degree Days (graaddagen) integratie",
         "data": {
-          "name": "Het voorvoegsel voor de namen van de Degree Day sensoren",
-          "heating limit": "Stookgrens",
-          "mean indoor temperature": "Etmaalgemiddelde binnentemperatuur",
           "weather station": "Weerstation (KNMI)",
+          "mean indoor temperature": "Etmaalgemiddelde binnentemperatuur",
+          "heating limit": "Stookgrens",
           "startday": "Startdag voor optelling totaal aantal graaddagen",
           "startmonth": "Startmaand voor optelling totaal aantal graaddagen",
-          "gas consumption": "Gas consumptie in m3 (wordt later aangepast naar een sensor entity)",
           "gas sensor": "Gas sensor entiteit"
         }
       }
@@ -29,13 +27,11 @@
       "user": {
         "title": "Degree Days integration opties",
         "data": {
-          "name": "Het voorvoegsel voor de namen van de Degree Day sensoren",
-          "heating limit": "Stookgrens",
-          "mean indoor temperature": "Etmaalgemiddelde binnentemperatuur",
           "weather station": "Weerstation (KNMI)",
+          "mean indoor temperature": "Etmaalgemiddelde binnentemperatuur",
+          "heating limit": "Stookgrens",
           "startday": "Startdag voor optelling totaal aantal graaddagen",
           "startmonth": "Startmaand voor optelling totaal aantal graaddagen",
-          "gas consumption": "Gas consumptie in m3 (wordt later aangepast naar een sensor entity)",
           "gas sensor": "Gas sensor entiteit"
         }
       }

--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,5 @@
   "name": "Degree-Days integration",
   "domains": "degree_days",
   "render_readme": true,
-  "homeassistant": "2021.9.0"
+  "homeassistant": "2021.10.0"
 }


### PR DESCRIPTION
Adding gas prognose and gas consumption per weighted degree days (will take 10 minutes after a restart). 

The 10 minute delay will be fixed in a future release. 